### PR TITLE
Improved error reporting

### DIFF
--- a/src/tools/builder/dynamicwallpaperdescriptionreader.cpp
+++ b/src/tools/builder/dynamicwallpaperdescriptionreader.cpp
@@ -100,7 +100,7 @@ bool DynamicWallpaperDescriptionReaderPrivate::read(int index)
 
     QString absoluteFileName = fileName.toString();
 
-    if (absoluteFileName == "") {
+    if (absoluteFileName.isEmpty()) {
         setError(i18n("FileName value was not specified for one or more of the images. Check your json file!"));
         return false;
     }

--- a/src/tools/builder/dynamicwallpaperdescriptionreader.cpp
+++ b/src/tools/builder/dynamicwallpaperdescriptionreader.cpp
@@ -99,6 +99,12 @@ bool DynamicWallpaperDescriptionReaderPrivate::read(int index)
     const QJsonValue fileName = descriptor[QLatin1String("FileName")];
 
     QString absoluteFileName = fileName.toString();
+    
+    if (absoluteFileName == "") {
+        setError(i18n("FileName value was not specified for one or more of the images. Check your json file!"));
+        return false;
+    }
+    
     if (!QFileInfo(fileName.toString()).isAbsolute())
         absoluteFileName = resolveFileName(fileName.toString());
 

--- a/src/tools/builder/dynamicwallpaperdescriptionreader.cpp
+++ b/src/tools/builder/dynamicwallpaperdescriptionreader.cpp
@@ -99,12 +99,12 @@ bool DynamicWallpaperDescriptionReaderPrivate::read(int index)
     const QJsonValue fileName = descriptor[QLatin1String("FileName")];
 
     QString absoluteFileName = fileName.toString();
-    
+
     if (absoluteFileName == "") {
         setError(i18n("FileName value was not specified for one or more of the images. Check your json file!"));
         return false;
     }
-    
+
     if (!QFileInfo(fileName.toString()).isAbsolute())
         absoluteFileName = resolveFileName(fileName.toString());
 


### PR DESCRIPTION
This week I lost 2h not understanding why the kdynamicwallpaperbuilder fails with message:
`"Failed to read /home/user/wallpaper: File not found"`
where `"wallpaper"` was the folder where the image files and the json file were located. And it indeed existed.

It turns out that I did not specify the "FileName" value for one of the image files in the json file.
Now, in this case, the program will print a much more helpful message.