### PR TITLE
Fix crash when creating a preview for wallpaper

### DIFF
--- a/src/declarative/dynamicwallpaperpreviewjob.cpp
+++ b/src/declarative/dynamicwallpaperpreviewjob.cpp
@@ -127,8 +127,8 @@ static DynamicWallpaperImageAsyncResult makePreview(const QString &fileName, con
         auto dark = std::min_element(metadata.begin(), metadata.end(), score_compare);
         auto light = std::max_element(metadata.begin(), metadata.end(), score_compare);
 
-        const QImage darkImage = reader.image(std::distance(metadata.begin(), dark));
-        const QImage lightImage = reader.image(std::distance(metadata.begin(), light));
+        const QImage darkImage = reader.image(dark->index());
+        const QImage lightImage = reader.image(light->index());
 
         preview = blend(darkImage, lightImage, 0.5);
 


### PR DESCRIPTION
With the recent metadata changes, the number of metadata items can be
greater than the number of images. For example, this can be the case
when a dynamic wallpaper reuses the same image at different times of the
day.

fixes #92