### PR TITLE
Make KDynamicWallpaperWriter consume less memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ include(KDEInstallDirs)
 include(KDECMakeSettings)
 include(KDECompilerSettings NO_POLICY_SCOPE)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/src/lib/kdynamicwallpaperwriter.h
+++ b/src/lib/kdynamicwallpaperwriter.h
@@ -11,6 +11,8 @@
 #include <QIODevice>
 #include <QImage>
 
+#include <optional>
+
 class KDynamicWallpaperMetaData;
 class KDynamicWallpaperWriterPrivate;
 
@@ -52,6 +54,9 @@ public:
 
     bool flush(QIODevice *device);
     bool flush(const QString &fileName);
+
+    void setMaxThreadCount(int max);
+    std::optional<int> maxThreadCount() const;
 
     WallpaperWriterError error() const;
     QString errorString() const;

--- a/src/lib/kdynamicwallpaperwriter.h
+++ b/src/lib/kdynamicwallpaperwriter.h
@@ -9,6 +9,7 @@
 #include "kdynamicwallpaper_export.h"
 
 #include <QIODevice>
+#include <QImage>
 
 class KDynamicWallpaperMetaData;
 class KDynamicWallpaperWriterPrivate;
@@ -23,14 +24,31 @@ public:
         UnknownError,
     };
 
+    class ImageView
+    {
+    public:
+        explicit ImageView(const QString &fileName)
+            : m_fileName(fileName)
+        {
+        }
+
+        QImage data() const
+        {
+            return QImage(m_fileName);
+        }
+
+    private:
+        QImage m_fileName;
+    };
+
     KDynamicWallpaperWriter();
     ~KDynamicWallpaperWriter();
 
     void setMetaData(const QList<KDynamicWallpaperMetaData> &metaData);
     QList<KDynamicWallpaperMetaData> metaData() const;
 
-    void setImages(const QList<QImage> &images);
-    QList<QImage> images() const;
+    void setImages(const QList<ImageView> &views);
+    QList<ImageView> images() const;
 
     bool flush(QIODevice *device);
     bool flush(const QString &fileName);

--- a/src/tools/builder/dynamicwallpaperdescription.cpp
+++ b/src/tools/builder/dynamicwallpaperdescription.cpp
@@ -65,7 +65,7 @@ void DynamicWallpaperDescription::init(const QString &metaDataFileName)
 
     QMap<int, QString> uniqueFileNames;
     QList<KDynamicWallpaperMetaData> metaDataList;
-    QList<QImage> imageList;
+    QList<KDynamicWallpaperWriter::ImageView> imageList;
 
     for (int i = 0; i < descriptors.size(); ++i) {
         const QJsonObject descriptor = descriptors[i].toObject();
@@ -163,7 +163,8 @@ void DynamicWallpaperDescription::init(const QString &metaDataFileName)
                     setError(QStringLiteral("%1: Failed to compute the position of the Sun based on GPS "
                                             "coordinates and the time when the photo was taken. Please check "
                                             "that the specified image actually has GPS coordinates in its "
-                                            "Exif metadata. You can do that with a tool such as exiftool.").arg(absoluteFileName));
+                                            "Exif metadata. You can do that with a tool such as exiftool.")
+                                 .arg(absoluteFileName));
                     return;
                 }
             }
@@ -174,7 +175,8 @@ void DynamicWallpaperDescription::init(const QString &metaDataFileName)
                     setError(QStringLiteral("%1: Failed to compute the position of the Sun based on GPS "
                                             "coordinates and the time when the photo was taken. Please check "
                                             "that the specified image actually has GPS coordinates in its "
-                                            "Exif metadata. You can do that with a tool such as exiftool.").arg(absoluteFileName));
+                                            "Exif metadata. You can do that with a tool such as exiftool.")
+                                 .arg(absoluteFileName));
                     return;
                 }
             }
@@ -191,15 +193,8 @@ void DynamicWallpaperDescription::init(const QString &metaDataFileName)
         metaDataList.append(metaData);
     }
 
-    for (const QString &fileName : uniqueFileNames) {
-        const QImage image(fileName);
-        if (!image.isNull()) {
-            imageList.append(image);
-        } else {
-            setError(QStringLiteral("Failed to load ") + fileName);
-            return;
-        }
-    }
+    for (const QString &fileName : uniqueFileNames)
+        imageList.append(KDynamicWallpaperWriter::ImageView(fileName));
 
     m_metaDataList = metaDataList;
     m_imageList = imageList;
@@ -231,7 +226,7 @@ QList<KDynamicWallpaperMetaData> DynamicWallpaperDescription::metaData() const
     return m_metaDataList;
 }
 
-QList<QImage> DynamicWallpaperDescription::images() const
+QList<KDynamicWallpaperWriter::ImageView> DynamicWallpaperDescription::images() const
 {
     return m_imageList;
 }

--- a/src/tools/builder/dynamicwallpaperdescription.h
+++ b/src/tools/builder/dynamicwallpaperdescription.h
@@ -7,10 +7,10 @@
 #pragma once
 
 #include <KDynamicWallpaperMetaData>
+#include <KDynamicWallpaperWriter>
 
 #include <QJsonArray>
 #include <QJsonObject>
-#include <QImage>
 #include <QString>
 
 class DynamicWallpaperDescription
@@ -20,7 +20,7 @@ public:
     ~DynamicWallpaperDescription();
 
     QList<KDynamicWallpaperMetaData> metaData() const;
-    QList<QImage> images() const;
+    QList<KDynamicWallpaperWriter::ImageView> images() const;
 
     bool hasError() const;
     QString errorString() const;
@@ -30,7 +30,7 @@ private:
     void setError(const QString &text);
 
     QList<KDynamicWallpaperMetaData> m_metaDataList;
-    QList<QImage> m_imageList;
+    QList<KDynamicWallpaperWriter::ImageView> m_imageList;
     QString m_errorString;
     bool m_hasError = false;
 };

--- a/src/tools/builder/main.cpp
+++ b/src/tools/builder/main.cpp
@@ -26,11 +26,16 @@ int main(int argc, char **argv)
     outputOption.setDescription(i18n("Write output to <file>"));
     outputOption.setValueName(QStringLiteral("file"));
 
+    QCommandLineOption maxThreadsOption(QStringLiteral("max-threads"));
+    maxThreadsOption.setDescription(i18n("Maximum number of threads that can be used during encoding wallpaper"));
+    maxThreadsOption.setValueName(QStringLiteral("max-threads"));
+
     QCommandLineParser parser;
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addPositionalArgument("json", i18n("Description file to use"));
     parser.addOption(outputOption);
+    parser.addOption(maxThreadsOption);
     parser.process(app);
 
     if (parser.positionalArguments().count() != 1)
@@ -46,6 +51,15 @@ int main(int argc, char **argv)
     KDynamicWallpaperWriter writer;
     writer.setImages(description.images());
     writer.setMetaData(description.metaData());
+
+    if (parser.isSet(maxThreadsOption)) {
+        bool ok;
+        if (const int threadCount = parser.value(maxThreadsOption).toInt(&ok); ok) {
+            writer.setMaxThreadCount(threadCount);
+        } else {
+            parser.showHelp(-1);
+        }
+    }
 
     QString targetFileName = parser.value(outputOption);
     if (targetFileName.isEmpty())


### PR DESCRIPTION
There are several issues with the current API design:

* metadata needs to describe the dynamic wallpaper, images are indexed
  using integers
* the writer cannot take images in online fashion because what if there
  are fewer images than in metadata, etc

In order to "solve" those problems, the API of KDynamicWallpaperWriter
was changed so it takes metadata and images before starting writing.

Conceptually, that is great, but loading all images in RAM is not great
plus AV1 encoders consume ridiculously too much memory.

As a compromise, this change makes the KDynamicWallpaperWriter take
image views and load images on demand. This slightly reduces memory
usage but it looks like avifEncoder API is not really great for online
encoding, so memory usage when building a dynamic wallpaper is still
high.

#90