### PR TITLE
Improve memory usage with 8K wallpapers

### DIFF
--- a/src/declarative/CMakeLists.txt
+++ b/src/declarative/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(plasma_wallpaper_dynamicplugin
     Qt5::Positioning
     Qt5::Qml
     Qt5::Quick
+    Qt5::QuickPrivate
 
     KF5::ConfigCore
     KF5::I18n

--- a/src/declarative/dynamicwallpaperimageprovider.h
+++ b/src/declarative/dynamicwallpaperimageprovider.h
@@ -6,10 +6,13 @@
 
 #pragma once
 
-#include <QQuickAsyncImageProvider>
+#include <QtQuick/private/qquickpixmapcache_p.h> // TODO: Use stable API in Qt 6
 
-class DynamicWallpaperImageProvider : public QQuickAsyncImageProvider
+class DynamicWallpaperImageProvider : public QQuickImageProviderWithOptions
 {
 public:
-    QQuickImageResponse *requestImageResponse(const QString &id, const QSize &requestedSize) override;
+    DynamicWallpaperImageProvider();
+
+    QQuickImageResponse *requestImageResponse(const QString &id, const QSize &requestedSize,
+                                              const QQuickImageProviderOptions &options) override;
 };

--- a/src/package/contents/ui/WallpaperImage.qml
+++ b/src/package/contents/ui/WallpaperImage.qml
@@ -20,6 +20,11 @@ Item {
     property url topLayer
 
     /*!
+     * The scaled width and height of the full-frame image.
+     */
+    property size sourceSize
+
+    /*!
      * The blend factor between the bottom layer and the top layer.
      *
      * The blend factor varies between 0 and 1. 0 means that only the bottom
@@ -58,6 +63,7 @@ Item {
         cache: wallpaper.configuration.Cache
         fillMode: root.fillMode
         source: root.bottomLayer
+        sourceSize: root.sourceSize
     }
 
     Image {
@@ -69,6 +75,7 @@ Item {
         fillMode: root.fillMode
         opacity: root.blendFactor
         source: root.topLayer
+        sourceSize: root.sourceSize
     }
 
     Behavior on blendFactor {

--- a/src/package/contents/ui/WallpaperView.qml
+++ b/src/package/contents/ui/WallpaperView.qml
@@ -35,6 +35,11 @@ StackView {
     property int fillMode
 
     /*!
+     * The scaled width and height of the full-frame image.
+     */
+    property size sourceSize
+
+    /*!
      * This property holds the wallpaper image about to be presented.
      */
     property WallpaperImage __nextItem: null
@@ -107,7 +112,8 @@ StackView {
             bottomLayer: bottomLayer,
             topLayer: topLayer,
             blendFactor: blendFactor,
-            fillMode: fillMode
+            fillMode: fillMode,
+            sourceSize: sourceSize
         });
 
         if (root.__nextItem.status == Image.Loading)

--- a/src/package/contents/ui/main.qml
+++ b/src/package/contents/ui/main.qml
@@ -33,6 +33,7 @@ Item {
         blendFactor: handler.blendFactor
         bottomLayer: handler.bottomLayer
         fillMode: wallpaper.configuration.FillMode
+        sourceSize: Qt.size(root.width, root.height)
         topLayer: handler.topLayer
         visible: handler.status == DynamicWallpaperHandler.Ready
         onStatusChanged: if (status != Image.Loading) {


### PR DESCRIPTION
Since Qt 5.15 is the last release in Qt 5 cycle, the private API of
QtQuick most likely won't change, so let's use
QQuickImageProviderWithOptions in order to reduce memory usage with
8K wallpapers.