### PR TITLE
Add encoding speed option

### DIFF
--- a/src/lib/kdynamicwallpaperwriter.cpp
+++ b/src/lib/kdynamicwallpaperwriter.cpp
@@ -36,6 +36,7 @@ public:
     QString errorString;
     QList<KDynamicWallpaperWriter::ImageView> images;
     QList<KDynamicWallpaperMetaData> metaData;
+    std::optional<int> speed;
     std::optional<int> maxThreadCount;
 };
 
@@ -90,6 +91,7 @@ bool KDynamicWallpaperWriterPrivate::flush(QIODevice *device)
 
     const QByteArray xmp = serializeMetaData(metaData);
     avifEncoder *encoder = avifEncoderCreate();
+    encoder->speed = speed.value_or(AVIF_SPEED_DEFAULT);
     encoder->maxThreads = maxThreadCount.value_or(QThread::idealThreadCount());
     auto encoderCleanup = qScopeGuard([&encoder]() {
         avifEncoderDestroy(encoder);
@@ -163,6 +165,25 @@ KDynamicWallpaperWriter::KDynamicWallpaperWriter()
  */
 KDynamicWallpaperWriter::~KDynamicWallpaperWriter()
 {
+}
+
+/*!
+ * Sets the encoding speed to \a speed. The speed value must be between 0 and 10, where
+ * 0 is the slowest speed, and 10 is the fastest speed. Encoding speed can affect encoding
+ * quality or file size.
+ */
+void KDynamicWallpaperWriter::setSpeed(int speed)
+{
+    d->speed = qBound(0, speed, 10);
+}
+
+/*!
+ * Returns the encoding speed, between 0-10. If the encoding speed is not set, the encoder
+ * will choose the most optimal encoding speed.
+ */
+std::optional<int> KDynamicWallpaperWriter::speed() const
+{
+    return d->speed;
 }
 
 void KDynamicWallpaperWriter::setMetaData(const QList<KDynamicWallpaperMetaData> &metaData)

--- a/src/lib/kdynamicwallpaperwriter.h
+++ b/src/lib/kdynamicwallpaperwriter.h
@@ -51,6 +51,9 @@ public:
     KDynamicWallpaperWriter();
     ~KDynamicWallpaperWriter();
 
+    void setSpeed(int speed);
+    std::optional<int> speed() const;
+
     void setMetaData(const QList<KDynamicWallpaperMetaData> &metaData);
     QList<KDynamicWallpaperMetaData> metaData() const;
 

--- a/src/tools/builder/main.cpp
+++ b/src/tools/builder/main.cpp
@@ -26,6 +26,10 @@ int main(int argc, char **argv)
     outputOption.setDescription(i18n("Write output to <file>"));
     outputOption.setValueName(QStringLiteral("file"));
 
+    QCommandLineOption speedOption(QStringLiteral("speed"));
+    speedOption.setDescription(i18n("Encoding speed, 0 - slowest, 10 - fastest"));
+    speedOption.setValueName(QStringLiteral("speed"));
+
     QCommandLineOption maxThreadsOption(QStringLiteral("max-threads"));
     maxThreadsOption.setDescription(i18n("Maximum number of threads that can be used when encoding a wallpaper"));
     maxThreadsOption.setValueName(QStringLiteral("max-threads"));
@@ -36,6 +40,7 @@ int main(int argc, char **argv)
     parser.addPositionalArgument("json", i18n("Manifest file to use"));
     parser.addOption(outputOption);
     parser.addOption(maxThreadsOption);
+    parser.addOption(speedOption);
     parser.process(app);
 
     if (parser.positionalArguments().count() != 1)
@@ -56,6 +61,15 @@ int main(int argc, char **argv)
         bool ok;
         if (const int threadCount = parser.value(maxThreadsOption).toInt(&ok); ok) {
             writer.setMaxThreadCount(threadCount);
+        } else {
+            parser.showHelp(-1);
+        }
+    }
+
+    if (parser.isSet(speedOption)) {
+        bool ok;
+        if (const int speed = parser.value(speedOption).toInt(&ok); ok) {
+            writer.setSpeed(speed);
         } else {
             parser.showHelp(-1);
         }


### PR DESCRIPTION
This adds --speed option in kdynamicwallpaperbuilder, 0 - slowest speed,
10 - fastest. The encoding speed can potentially affect encoding quality.

Example usage:

    kdynamicwallpaperbuilder --output foo.avif --speed 6 manifest.json

closes #107 